### PR TITLE
use common pg role name 'flyptox' for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,23 @@ From within the root directory:
 
 ```sh
 sudo npm install -g bower
+sudo npm install -g knex
 npm install
 bower install
 ```
 
 ### Database setup
-Create a database using commandline tool
+
+Create a database using `createdb` tool
 
     createdb flyptox
 
-In `psql` command line tool create a role and grant access to the database:
+Enter `psql` command shell. Create a role and grant access to the database
 
     create role flyptox with login;
     grant all privileges on database flyptox to flyptox;
+
+exit psql
 
 Run knex migrations
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ npm install
 bower install
 ```
 
+### Database setup
+Create a database using commandline tool
+
+    createdb flyptox
+
+In `psql` command line tool create a role and grant access to the database:
+
+    create role flyptox with login;
+    grant all privileges on database flyptox to flyptox;
+
+Run knex migrations
+
+    knex migrate:latest
+
 ### Roadmap
 
 View the project roadmap [here](LINK_TO_PROJECT_ISSUES)

--- a/knexfile.js
+++ b/knexfile.js
@@ -5,7 +5,7 @@ module.exports = {
     connection: {
       host: 'localhost',
       database: 'flyptox',
-      user:     'Amylia'
+      user:     'flyptox'
     },
     seeds: {
       directory: './db/seeds'


### PR DESCRIPTION
I suggest we use a common role (username) for knex configuration.

To create a flyptox user in postgres run the following command in `psql` 

    create role flyptox with login;
    grant all privileges on database flyptox to flyptox;