### PR TITLE
added .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+ "directory": "client/bower_components"
+}


### PR DESCRIPTION
bower components will be installed into  `client/bower_components` instead of the root directory