### PR TITLE
Updated readme with test/testdb info

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,9 @@ module.exports = function(grunt) {
         },
         // Configure mochaTest tasks
         mochaTest: {
+          options: {
+
+          },
           server: {
             src: ['test/server/**/*.spec.js']
           },
@@ -261,9 +264,14 @@ module.exports = function(grunt) {
   ]);
 
   // tast for running mocha tests on server components
-  grunt.registerTask('test:server', ['mochaTest:server']);
-  grunt.registerTask('test:models', ['mochaTest:models']);
-  grunt.registerTask('test:controllers', ['mochaTest:controllers']);
+  // use the format `grunt test:TYPE` where type i
+  // is the type of test you want to run
+  // test:server runs all server tests
+  grunt.registerTask('test', function(testType){
+    testType = testType || 'server';
+    process.env.NODE_ENV = 'test';
+    grunt.task.run('mochaTest:' + testType);
+  });
 
   function setEnvVars() {
     if(minOption()) {

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ Run knex migrations
 ### Testing
 
 #### Server side
-- `NODE_ENV=test grunt test:server` to run all server tests
-- `NODE_ENV=test grunt test:models` to run only model tests
-- `NODE_ENV=test grunt test:controllers` to run only controller tests
+- `grunt test:server` to run all server tests
+- `grunt test:models` to run only model tests
+- `grunt test:controllers` to run only controller tests
 
 #### Client side
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,30 @@ Run knex migrations
 
     knex migrate:latest
 
+### Test Database Setup
+
+1. make sure you have followed the steps from above 'Database Setup'
+2. configure your knexfile.js admin object.
+   - your admin object should have postgres credentials to an admin level account
+   - most likely your system username and an empty password
+4. run `node server/utils/recreateDB`
+   - this will drop the test db and recreate it with the latest migration/seeds
+
+### Testing
+
+#### Server side
+- `NODE_ENV=test grunt test:server` to run all server tests
+- `NODE_ENV=test grunt test:models` to run only model tests
+- `NODE_ENV=test grunt test:controllers` to run only controller tests
+
+#### Client side
+
+
 ### Roadmap
 
 View the project roadmap [here](https://github.com/FlipSideHR/FlyptoX/issues)
 
-
 ## Contributing
 
+PR's are welcome.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
This PR just adds some instructions to the readme about using the testDB, and grunt test commands.

It also removes the need to prefix tests with NODE_ENV. Grunt takes care of this for us now.