### PR TITLE
Orderbook

### DIFF
--- a/server/controllers/book.js
+++ b/server/controllers/book.js
@@ -80,20 +80,25 @@ OrderBook.level = {
         .fetchAll()
         .then(function(orders){
           return orders.map(function(order){
-            return [order.get('price'), order.get('size'), order.get('id')];
+            return [order.get('price').toFixed(2), order.get('size').toFixed(8), order.get('id')];
           });
         }),
 
       //asks
       Order.where({status:'open', type:"limit", side:"sell", currency_pair_id: pair_id})
-        .query('orderBy','price','desc')
+        .query('orderBy','price','asc')
         .fetchAll()
         .then(function(orders){
           return orders.map(function(order){
-            return [order.get('price'), order.get('size'), order.get('id')];
+            return [order.get('price').toFixed(2), order.get('size').toFixed(8), order.get('id')];
           });
         })
-    ]);
+    ]).then(function(book){
+      return {
+        bids: book[0],
+        asks: book[1]
+      }
+    })
   },
 
   "2": function(pair_id){

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -47,10 +47,7 @@ router.get("/products/:id/book", function(req, res){
   //level: req.query.level
   //pair: req.params.id
   OrderBook.level[req.query.level || 2](req.params.id).then(function(book){
-    res.json({
-      bids: book[0],
-      asks: book[1]
-    });
+    res.json(book);
   })
   .catch(function(err){
     res.status(500).json({message:'unable to retrieve orderbook'});

--- a/test/server/controllers/book.order.aggregation.spec.js
+++ b/test/server/controllers/book.order.aggregation.spec.js
@@ -1,0 +1,98 @@
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should();
+
+var bookshelf = require("../../../server/utils/bookshelf");
+var Order = require("../../../server/utils/models").Order;
+var User = require("../../../server/utils/models").User;
+var helpers = require("../models/helpers");
+
+var Orders = bookshelf.Collection.extend({
+  model: Order
+});
+
+function makeUser(done){
+  User.forge({email:"test", password:"test"}).save().finally(done);
+}
+
+function makeOrder(user_id, side, price, size) {
+  return {
+    currency_pair_id: 1,
+    type:'limit',
+    side:side,
+    status:'open',
+    price: price,
+    size: size,
+    user_id: user_id
+  };
+}
+
+//collection is ordered, implement the order method (like backbone?)
+//to ensure when a model is added it goes into proper order
+//also note: make sure query to load collection orders by price then, created_at
+//does the sort run when models are fetched?
+function makeOrderBook(done){
+    User.forge({email:"test"}).fetch()
+    .then(function(user){
+      var orders = Orders.forge([
+        makeOrder(user.get('id'), 'buy', 201, 0.5),
+        makeOrder(user.get('id'), 'buy', 203, 0.5),
+        makeOrder(user.get('id'), 'buy', 204, 1.0),
+        makeOrder(user.get('id'), 'buy', 205, 0.5),
+        makeOrder(user.get('id'), 'buy', 204, 1.0),
+        makeOrder(user.get('id'), 'buy', 300, 0.5),
+        makeOrder(user.get('id'), 'buy', 300, 0.5),//best bid (highest buy order)
+        makeOrder(user.get('id'), 'sell', 100, 0.5),//best ask (lowest sell order)
+        makeOrder(user.get('id'), 'sell', 300, 0.5),
+        makeOrder(user.get('id'), 'sell', 400, 0.5),
+        makeOrder(user.get('id'), 'sell', 400, 0.5),
+        makeOrder(user.get('id'), 'sell', 200, 0.5),
+        makeOrder(user.get('id'), 'sell', 200, 0.5),
+      ]);
+
+      return Promise.all(orders.invoke('save'));
+    })
+    .catch(done)
+    .finally(function(){
+      done();
+    });
+}
+
+describe('Order Aggregator', function(){
+  before(helpers.clean);
+  before(makeUser);
+  before(makeOrderBook);
+
+  var orderBook = require("../../../server/controllers/book");
+
+  it('level 1 - should return best bid and ask from the order book', function(done){
+    orderBook.level[1](1).then(function(book){
+      expect(book.bids).to.deep.equal([
+        [300, 1, 2],
+      ]);
+
+      expect(book.asks).to.deep.equal([
+        [100, 0.5, 1]
+      ]);
+      done();
+    })
+    .catch(function(err){
+      done(err)
+    });
+  });
+
+  xit('level 2 - should return top 50 best bids and asks from the order book', function(){
+
+  });
+
+  xit('level 3 - should return all bids and asks from the order book', function(){
+
+  });
+
+});
+
+describe('Order Aggregator - Level 2', function(){
+
+
+
+});

--- a/test/server/controllers/book.order.aggregation.spec.js
+++ b/test/server/controllers/book.order.aggregation.spec.js
@@ -34,20 +34,21 @@ function makeOrder(user_id, side, price, size) {
 function makeOrderBook(done){
     User.forge({email:"test"}).fetch()
     .then(function(user){
+      var uid = user.get('id');
       var orders = Orders.forge([
-        makeOrder(user.get('id'), 'buy', 201, 0.5),
-        makeOrder(user.get('id'), 'buy', 203, 0.5),
-        makeOrder(user.get('id'), 'buy', 204, 1.0),
-        makeOrder(user.get('id'), 'buy', 205, 0.5),
-        makeOrder(user.get('id'), 'buy', 204, 1.0),
-        makeOrder(user.get('id'), 'buy', 300, 0.5),
-        makeOrder(user.get('id'), 'buy', 300, 0.5),//best bid (highest buy order)
-        makeOrder(user.get('id'), 'sell', 100, 0.5),//best ask (lowest sell order)
-        makeOrder(user.get('id'), 'sell', 300, 0.5),
-        makeOrder(user.get('id'), 'sell', 400, 0.5),
-        makeOrder(user.get('id'), 'sell', 400, 0.5),
-        makeOrder(user.get('id'), 'sell', 200, 0.5),
-        makeOrder(user.get('id'), 'sell', 200, 0.5),
+        makeOrder(uid, 'buy', 201, 0.5),
+        makeOrder(uid, 'buy', 203, 0.5),
+        makeOrder(uid, 'buy', 204, 1.0),
+        makeOrder(uid, 'buy', 205, 0.5),
+        makeOrder(uid, 'buy', 204, 1.0),
+        makeOrder(uid, 'buy', 300, 0.5),
+        makeOrder(uid, 'buy', 300, 0.5),//best bid (highest buy order)
+        makeOrder(uid, 'sell', 100, 0.5),//best ask (lowest sell order)
+        makeOrder(uid, 'sell', 300, 0.5),
+        makeOrder(uid, 'sell', 400, 0.5),
+        makeOrder(uid, 'sell', 400, 0.5),
+        makeOrder(uid, 'sell', 200, 0.5),
+        makeOrder(uid, 'sell', 200, 0.5),
       ]);
 
       return Promise.all(orders.invoke('save'));
@@ -68,31 +69,41 @@ describe('Order Aggregator', function(){
   it('level 1 - should return best bid and ask from the order book', function(done){
     orderBook.level[1](1).then(function(book){
       expect(book.bids).to.deep.equal([
-        [300, 1, 2],
+        ["300.00", "1.00000000", 2],
       ]);
 
       expect(book.asks).to.deep.equal([
-        [100, 0.5, 1]
+        ["100.00", "0.50000000", 1]
       ]);
       done();
     })
-    .catch(function(err){
-      done(err)
-    });
+    .catch(done);
   });
 
-  xit('level 2 - should return top 50 best bids and asks from the order book', function(){
+  it('level 2 - should return top 50 best bids and asks from the order book', function(done){
+    orderBook.level[2](1).then(function(book){
+      expect(book.bids).to.deep.equal([
+        ["201.00", "0.50000000", 1],
+        ["203.00", "0.50000000", 1],
+        ["204.00", "2.00000000", 2],
+        ["205.00", "0.50000000", 1],
+        ["300.00", "1.00000000", 2]
+      ]);
 
+      expect(book.asks).to.deep.equal([
+        ["100.00", "0.50000000", 1],
+        ["200.00", "1.00000000", 2],
+        ["300.00", "0.50000000", 1],
+        ["400.00", "1.00000000", 2]
+      ]);
+
+      done();
+    })
+    .catch(done);
   });
 
   xit('level 3 - should return all bids and asks from the order book', function(){
 
   });
-
-});
-
-describe('Order Aggregator - Level 2', function(){
-
-
 
 });

--- a/test/server/controllers/book.order.aggregation.spec.js
+++ b/test/server/controllers/book.order.aggregation.spec.js
@@ -43,12 +43,12 @@ function makeOrderBook(done){
         makeOrder(uid, 'buy', 204, 1.0),
         makeOrder(uid, 'buy', 300, 0.5),
         makeOrder(uid, 'buy', 300, 0.5),//best bid (highest buy order)
-        makeOrder(uid, 'sell', 100, 0.5),//best ask (lowest sell order)
         makeOrder(uid, 'sell', 300, 0.5),
         makeOrder(uid, 'sell', 400, 0.5),
         makeOrder(uid, 'sell', 400, 0.5),
         makeOrder(uid, 'sell', 200, 0.5),
         makeOrder(uid, 'sell', 200, 0.5),
+        makeOrder(uid, 'sell', 100, 0.5),//best ask (lowest sell order)
       ]);
 
       return Promise.all(orders.invoke('save'));
@@ -59,7 +59,7 @@ function makeOrderBook(done){
     });
 }
 
-describe('Order Aggregator', function(){
+describe('Order Book', function(){
   before(helpers.clean);
   before(makeUser);
   before(makeOrderBook);
@@ -102,8 +102,17 @@ describe('Order Aggregator', function(){
     .catch(done);
   });
 
-  xit('level 3 - should return all bids and asks from the order book', function(){
+  it('level 3 - should return all bids and asks from the order book', function(done){
+    orderBook.level[3](1).then(function(book){
 
+      expect(book.bids.length).to.equal(7);
+      expect(book.bids[0][0]).to.equal('201.00');
+      expect(book.bids[0][1]).to.equal('0.50000000');
+      expect(book.asks.length).to.equal(6);
+      expect(book.asks[0][0]).to.equal('100.00');
+      expect(book.asks[0][1]).to.equal('0.50000000');
+      done();
+    }).catch(done);
   });
 
 });


### PR DESCRIPTION
REST API can finally retrieve the order book in 3 distinct levels of detail (exactly like coinbase)

`/api/v1/products/:id/book?level=L`

So to get the level 3 order book for USD-BTC,  (id = 1) (L =3)

`/api/v1/products/1/book?level=3`

The default is level 2 (which is an aggregation of the top 50 bids and asks)

Unit tests included and passing.