### PR TITLE
recreateDB script updated and minor model/test updates.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ dist/
 
 # test generated output
 results.txt
+
+# knexfile - the master copy of this file works for travis, but most likeley
+# will require some changes to run on your dev environment. see the README.md
+knexfile.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 install:
   - npm install 
 before_script:
-  - node server/utils/recreateDB.js
+  - node server/utils/recreateDB.js -travis
 
 language: node_js
 node_js:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/FlipSideHR/FlyptoX.svg?branch=master)](https://travis-ci.org/FlipSideHR/FlyptoX)
+
 # FlyptoX
 
 > Pithy project description

--- a/knexfile.js
+++ b/knexfile.js
@@ -32,6 +32,14 @@ module.exports = {
     client: 'pg',
     connection: {
       host: 'localhost',
+      database: 'recursion',
+      user:     'recursion'
+    },
+  },
+  travis: {
+    client: 'pg',
+    connection: {
+      host: 'localhost',
       database: 'postgres',
       user:     'postgres'
     },

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -5,6 +5,44 @@ require("./User");
 require("./CurrencyPair");
 require("./Transaction");
 
+// minimum posible order size
+// TODO: let the administrator configure this
+var MIN_SIZE = 0.001;
+
+var orderTypes = {
+  'market': 'market',
+  'limit': 'limit',
+  'test': 'test'
+};
+var validate = function(order){
+  // valid currency pair
+  // TODO: validate that order.get('currency_pair') is real
+
+  // valid order type (market/limit)
+  if(orderTypes[order.get('type')] === 'undefined'){
+    throw Error('Invalid order type');
+  }
+
+  // valid side (buy/sell)
+  if (order.get('side') !== 'buy' && order.get('side') !== 'sell'){
+    throw Error('Invalid Order Side: ' + order.get('side') + ' . Must be "buy" or "sell"');
+  }
+
+  // valid price - must be positive number
+  if (order.get('price') <= 0 || typeof order.get('price') !== 'number'){
+    throw Error('Price must be a positive number');
+  }
+
+  // valid size
+  if (order.get('size') < MIN_SIZE) {
+    throw Error('Size must be ' + MIN_SIZE + ' or more.');
+  }
+
+  // starts with filledSize of 0
+  // starts with status of open
+  // starts with done_reason of null
+};
+
 var Order = module.exports = bookshelf.model('Order', {
   tableName: 'orders',
 
@@ -14,6 +52,9 @@ var Order = module.exports = bookshelf.model('Order', {
 
   // order creation event
   onCreate: function(model, attrs, options) {
+    // validate this order data before creating
+    validate(this);
+
     this.set('id', uuid.v1());
   },
 

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -58,6 +58,8 @@ var Order = module.exports = bookshelf.model('Order', {
     this.set('id', uuid.v1());
   },
 
+  MIN_SIZE: MIN_SIZE,
+
   currency_pair: function(){
     return this.belongsTo('CurrencyPair','currency_pair_id');
   },
@@ -68,6 +70,6 @@ var Order = module.exports = bookshelf.model('Order', {
 
   transactions: function(){
     return this.hasMany('Transaction', 'order_id');
-  }
+  },
 
 });

--- a/server/test/models/helpers.js
+++ b/server/test/models/helpers.js
@@ -62,6 +62,9 @@ utils.trade = {
 };
 
 utils.order = {
+  createCustom: function(params){
+    return Order.forge(params).save({}, {method: 'insert'});
+  },
   createOrder: function(uid){
 
     var myOrder = {

--- a/server/test/models/order.model.spec.js
+++ b/server/test/models/order.model.spec.js
@@ -58,8 +58,9 @@ describe('Order Model', function(){
     expect(Order).to.not.equal(null);
   });
 
-  describe('.side', function(){
 
+
+  describe('.side', function(){
     it('cannot be empty', function(done){
       // test with no 'side' value defined
       myOrder.side = undefined;
@@ -88,6 +89,49 @@ describe('Order Model', function(){
     });
   });
 
+  describe('.price', function(){
+    it('must be a positive number.', function(done){
+      myOrder.price = -500.55;
+      utils.order.createCustom(myOrder)
+        .then(function(order){
+          expect(order).to.equal(null);
+          done();
+        })
+        .catch(function(err){
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+  });
+
+  describe('.size', function(){
+    it('must be a positive number.', function(done){
+      myOrder.size = -5;
+      utils.order.createCustom(myOrder)
+        .then(function(order){
+          expect(order).to.equal(null);
+          done();
+        })
+        .catch(function(err){
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+
+    it('must be greater than MIN_SIZE: '+new Order().MIN_SIZE, function(done){
+      myOrder.size = 0.0001;
+      utils.order.createCustom(myOrder)
+        .then(function(order){
+          expect(order).to.equal(null);
+          done();
+        })
+        .catch(function(err){
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+  });
+
   it('creates new orders when given proper inputs: ', function(done){
     utils.order.createOrder(uid)
       .then(function(order){
@@ -101,7 +145,10 @@ describe('Order Model', function(){
       });
   });
 
-  // this isnt working as expected
+  it('Has a MIN_SIZE property', function(){
+    expect(new Order().MIN_SIZE).to.equal(0.001);
+  });
+
   it('references a real user', function(done){
     Order.fetchAll()
       .then(function(orders){

--- a/server/test/models/order.model.spec.js
+++ b/server/test/models/order.model.spec.js
@@ -17,6 +17,18 @@ describe('Order Model', function(){
   // this is for certain tests that require a valid user id
   var uid;
 
+  // a generic order
+  var myOrder = {
+    sequence: 1,
+    currency_pair_id: 1,
+    type: 'limit',
+    price: 301.01,
+    side: 'buy',
+    size: 50,
+    filled_size: 0,
+    user_id: uid
+  };
+
   // create an array to hold on to test orders we create
   // so they can easily be deleted later
 
@@ -46,6 +58,36 @@ describe('Order Model', function(){
     expect(Order).to.not.equal(null);
   });
 
+  describe('.side', function(){
+
+    it('cannot be empty', function(done){
+      // test with no 'side' value defined
+      myOrder.side = undefined;
+      utils.order.createCustom(myOrder)
+        .then(function(order){
+          expect(order).to.equal(null);
+          done();
+        })
+        .catch(function(err){
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+    it('must be the string "buy" or "sell"', function(done){
+      // test with a junk string
+      myOrder.side = 'someJunKValue';
+      utils.order.createCustom(myOrder)
+        .then(function(order){
+          expect(order).to.equal(null);
+          done();
+        })
+        .catch(function(err){
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+  });
+
   it('creates new orders when given proper inputs: ', function(done){
     utils.order.createOrder(uid)
       .then(function(order){
@@ -60,19 +102,18 @@ describe('Order Model', function(){
   });
 
   // this isnt working as expected
-  xit('references a real user', function(done){
-    Order.fetchAll({withRelated: ['userId']})
+  it('references a real user', function(done){
+    Order.fetchAll()
       .then(function(orders){
-        //console.log(orders.models[0].related('user'));
-        //console.log(orders.models[0].userId());
-        //console.log(orders.models[0].related('userId'));
-
-        // this test isnt a real test - it fails just to let you kno
-        // there is a problem with this test in general
-        expect(orders.models[0]).to.equal(null);
-        done();
+        orders.at(0)
+          .load(['user'])
+          .then(function(model){
+            expect(model.relations.user.id === uid);
+            done();
+          });
       })
       .catch(function(err){
+        console.log(err);
         expect(err).to.equal(null);
         done();
       });

--- a/server/utils/recreateDB.js
+++ b/server/utils/recreateDB.js
@@ -50,7 +50,7 @@ knex.raw('DROP DATABASE IF EXISTS ' + database + ';')
   })
   .then(function(){
     console.log('Granting privileges!');
-    return knex.raw('grant all privileges on database flyptox_test to flyptox_test;');
+    return knex.raw('grant all privileges on database '+database+' to '+database+';');
   })
   .then(function(){
     console.log('Disconnecting from DB');

--- a/server/utils/recreateDB.js
+++ b/server/utils/recreateDB.js
@@ -6,10 +6,33 @@
 // and adds proper privileges, and runs migrations and seeds
 // TODO: same thing for the development db
 "use strict"; 
-var database = 'flyptox_test';
 
 var knexConfig = require('../../knexfile');
-var knex = require('knex')(knexConfig.admin);
+
+// assume its the test db unless otherwise specified
+var database = 'flyptox_test';
+
+// default knex config to use (should be a local pg account with admin access)
+var kConfig = knexConfig.admin;
+
+// see if an options switch was used
+// always ignore first 2 args
+process.argv.slice(2).forEach(function(val, index, array){
+  if (val[0] === '-'){
+    // option switch used -check flag
+    console.log(val);
+    // check for dev flag
+    if (val.slice(1) === 'dev'){
+      // set database to development
+      database = 'flyptox';
+    } else if (val.slice(1) === 'travis'){
+      // set user to travis
+      kConfig = knexConfig.travis;
+    }
+  }
+});
+
+var knex = require('knex')(kConfig);
 
 console.log('Dropping database!' + database);
 knex.raw('DROP DATABASE IF EXISTS ' + database + ';')


### PR DESCRIPTION
This PR introduces an update to the recreateDB script which now accepts option flags.
- `node server/utils/recreateDB`  drop, recreate, add privs, migrate and seed the **test** db.
- `node server/utils/recreateDB -dev` drop, recreate, add privs, migrate and seed the **dev** db.
- `node server/utils/recreateDB -travis` uses the knexfile travis config. 

Which brings us to the knexfile.
- The knexfile now has a travis setting which can be left alone
- The knexfile also has an admin setting which requires your postgres username and db (it signs in with these to manipulate the test and dev dbs.)
- TODO: So now that we can use this method to create the DB, the readme file needs to be updated with the correct (simpler) instructions.

I also added some new validations and tests on the orders model.

Hopefully not too many different things for one PR. :)
