### PR TITLE
Implemented 'gulp serverTestRunner' which lints/tests server files on update.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -239,6 +239,7 @@ gulp.task('build', ['sass', 'scripts', 'copy-html']);
 gulp.task('serverTestRunner', function(){
   argv.reporter = 'nyan';
   process.env.TESTRUNNER = 'continuous';
+  gulp.start('test:server');
   gulp.watch(paths.server.all, ['test:server']);
 });
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -145,18 +145,20 @@ gulp.task('test:client', ['lint:client'], function(done) {
 gulp.task('test:server', ['lint:server'], function() {
   process.env.NODE_ENV = 'test';
   return gulp.src(paths.server.spec.all)
-    // only run mocha tests if server files
     .pipe(plugins.mocha({
       reporter: argv.reporter || 'spec'
     }))
     .once('error', function () {
-      process.exit(1);
+      if (process.env.TESTRUNNER !== 'continuous'){
+        process.exit(1);
+      }
     })
     .once('end', function () {
-      process.exit();
+      if (process.env.TESTRUNNER !== 'continuous'){
+        process.exit();
+      }
     });
 });
-
 
 /////////////////////////////////////////
 //                  WATCH TASKS
@@ -236,12 +238,14 @@ gulp.task('build', ['sass', 'scripts', 'copy-html']);
 // a task for just running linter/tests on the server
 gulp.task('serverTestRunner', function(){
   argv.reporter = 'nyan';
+  process.env.TESTRUNNER = 'continuous';
   gulp.watch(paths.server.all, ['test:server']);
 });
 
 // our default task
 // always require a build first
 gulp.task('default', ['build'], function(){
+  process.env.TESTRUNNER = 'continuous';
   gulp.start('watch');
   gulp.start('browser-sync');
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -233,6 +233,12 @@ gulp.task('browser-sync', ['nodemon'], function(cb) {
 // always clean dist dir first
 gulp.task('build', ['sass', 'scripts', 'copy-html']);
 
+// a task for just running linter/tests on the server
+gulp.task('serverTestRunner', function(){
+  argv.reporter = 'nyan';
+  gulp.watch(paths.server.all, ['test:server']);
+});
+
 // our default task
 // always require a build first
 gulp.task('default', ['build'], function(){

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 # FlyptoX
 
 > FlyptoX is an open-source crypto currency exchange generator.
-####**Currently under development and not in a usable state
-- Basically: A generator that allows you to configure, create, and deploy your own crypto-currency exchange.
+####**Currently under development and not ready for production use.
+- A generator that allows you to configure, create, and deploy your own crypto-currency exchange.
 - The exchange supports crypto->crypto, testnet->testnet, testnet->virtualUSD exchanges out of the box.
-- Fiat currency withdrawels, deposits, wallets, and trading is supported - but you as exchange operator must enable these processes and the required compliance processes required in your region.
+- Crypto->Fiat exchange requires extra setup for regulation compliance and chargeback protections. This is the responsibility of the exchange operator to implement.
+- *Fiat currency withdrawals, deposits, wallets, and trading is supported - but you as exchange operator must enable these processes and the required compliance processes required in your region.*
 
 TODO:
 - Everything.
@@ -29,6 +30,7 @@ TODO:
 
 ## Usage
 
+**NOT IMPLEMENTED**
 > `npm install flyptox`
 
 > `yo flyptox`
@@ -59,17 +61,23 @@ bower install
 
 ### Database setup
 
-- Edit the knexfile.js
-   - set admin: username and database to your postgres admin user
-- run `node server/utils/recreateDB -dev`
-- run `node server/utils/recreateDB`
+##### Edit the knexfile.js
+ - The knexfile has 4 configs: test, development, travis, and admin.
+ - Test and development should always stay as they are.
+ - Admin should be the postgres username and database you use on your dev machine (almost definitely your username)
+
+##### run the db create/migrate/seed script
+- `node server/utils/recreateDB -dev` to build out the dev db
+- `node server/utils/recreateDB` to build out the test db (tests run against this)
+
+### Now You are ready to develop!
+- `gulp` builds the client, starts nodemon running the server, and launches browser-sync to auto inject any clientside changes. 
+- `gulp serverTestRunner` runs a watcher on server files, and runs linting and tests when they change.
 
 ### Testing
 
 #### Server side
 - `gulp test:server` to run all server tests
-- ~~`grunt test:models` to run only model tests~~
-- ~~`grunt test:controllers` to run only controller tests~~
 
 #### Client side
 - `gulp test:client` to run all client tests

--- a/server/models/Order.js
+++ b/server/models/Order.js
@@ -1,6 +1,7 @@
 var bookshelf = require('../utils/bookshelf');
 var uuid = require('node-uuid');
 
+
 require("./User");
 require("./CurrencyPair");
 require("./Transaction");


### PR DESCRIPTION
This is basically what running `gulp` does except there is no browser-sync, no watching client-files, not even a server running. 

just run `gulp serverTestRunner` and gulp will watch all server files for changes, then lint and test (with nyan cat reporting)