### PR TITLE
Added build path with no minification. (build path with minification remains)

### DIFF
--- a/client/app/app.html
+++ b/client/app/app.html
@@ -1,6 +1,5 @@
-<h1> Welcome to Flyptox! </h1>
+<h5> Welcome to Flyptox! </h5>
 
 <a ui-sref="orderbook">Orderbook</a> | <a ui-sref="chart">Chart</a>
-
 <div ui-view>
 </div>

--- a/server/main.js
+++ b/server/main.js
@@ -14,16 +14,23 @@ app.set('view engine', 'html');
 
 //signin and signup routes
 var authRouter = require("./routes/auth.js");
+app.use('/api/auth', authRouter);
 
 //api routes
 var apiRouter = require("./routes/api.js");
-
 app.use('/api/v1', apiRouter);
-app.use('/api/auth', authRouter);
 
+// serve all files from client/dist
 app.use('/', express.static(path.join(rootPath, 'client/dist/')));
 
 app.get('/', function(req, res) {
+  res.render('index.html');
+});
+
+// TODO: Error Handing here??
+
+// render everything that didnt get caught as index page
+app.use(function(req, res) {
   res.render('index.html');
 });
 

--- a/server/views/index.html
+++ b/server/views/index.html
@@ -25,11 +25,12 @@
     <div class="container" ui-view></div>
 
     <!--
-    load our minified js
+    load our js
+
     TODO: have gulp change this to non-min version during dev
     so we can remove the minification time from build process during dev
     gulp can just write this line based on the environment or something
     -->
-    <script src="/app/main.min.js"></script>
+    <script src="/app/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Ok, in the interest of faster builds, and less crud to suffer through, I removed minification from the default build path. 

Now gulp with just concat the JS and put it in dist.

To create a minified version use `gulp build-dist`. This currently will not be used by the application, but we will eventually make gulp smart enough to tell the index.html file whether to use minified js or regular js based on the environment its running in. For now not using minification keeps things simple, and fast for development.