### PR TITLE
Turned gulp browser-sync off by default.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -274,5 +274,10 @@ gulp.task('serverTestRunner', function(){
 gulp.task('default', ['build'], function(){
   process.env.TESTRUNNER = 'continuous';
   gulp.start('watch');
-  gulp.start('browser-sync');
+
+  if (argv.bs){
+    gulp.start('browser-sync');
+  } else {
+    gulp.start('nodemon');
+  }
 });


### PR DESCRIPTION
Since browser-sync's socket.io is conflicting with the applications, it has been turned off by default. 

In my **extremely limited** testing, I found that even though the browser was showing an error, both browser-sync and the application **appeared** to still be consuming and responding to socket data, so you can still use gulp with the switch `gulp --bs` to use browser sync if you find it useful and want to see if it works for you.

Otherwise just run `gulp` and connect to the server in your browser as normal (localhost:9999).