### PR TITLE
emit JSON in trade event, not a bookshelf model

### DIFF
--- a/server/controllers/matcher.js
+++ b/server/controllers/matcher.js
@@ -2,9 +2,6 @@ var bookshelf = require('../utils/bookshelf');
 var Promise = require('bluebird');
 var appEvents = require('./app-events');
 
-var Order = bookshelf.model('Order');
-var Trade = bookshelf.model('Trade');
-
 appEvents.on('order:new', processOrder);
 
 module.exports.processOrder = processOrder;
@@ -87,7 +84,7 @@ function loopOverOrders(info) {
         }
       })
       .then(function(results){
-        appEvents.emit('trade', results[2]);
+        appEvents.emit('trade', results[2].toJSON());
 
         if (order.get('status') === 'done') {
           resolve();

--- a/server/controllers/web-market-streamer.js
+++ b/server/controllers/web-market-streamer.js
@@ -13,7 +13,7 @@ appEvents.on('order:cancelled', function(order) {
 });
 
 appEvents.on('trade', function(trade){
-  console.log('Trade occured', trade.get('price'));
+  console.log('Trade occured @', trade.price);
   io.emit('trade', trade);
 });
 


### PR DESCRIPTION
Just attempting to keep a consistent data format of the models when being passed around in events.. with the data returned from api calls..  so data format coming down the pipe over socket.io and rest api calls is identical.. 

Need to redo this again later.. especially  to make sure date strings are always in ISO 8601 format.

Best place I think would be to override toJSON in the bookshelf  model definition.

I'll explore that and come back with a solution.

This PR however can me merged once reviewed.