### PR TITLE
async event emitter, and async queue for order matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "yargs": "^3.15.0"
   },
   "dependencies": {
+    "async": "^1.4.0",
     "async-eventemitter": "^0.2.2",
     "bcrypt-nodejs": "0.0.3",
     "bluebird": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "yargs": "^3.15.0"
   },
   "dependencies": {
+    "async-eventemitter": "^0.2.2",
     "bcrypt-nodejs": "0.0.3",
     "bluebird": "^2.3.6",
     "body-parser": "^1.9.0",

--- a/server/controllers/app-events.js
+++ b/server/controllers/app-events.js
@@ -9,7 +9,7 @@
   to run controllers on separate nodes, making the application scale horizontally
   when required.
 */
-var EventEmitter = require('events').EventEmitter;
+var AsyncEventEmitter = require('async-eventemitter');
 
 
-module.exports = new EventEmitter();
+module.exports = new AsyncEventEmitter();

--- a/server/test/controllers/matcher.spec.js
+++ b/server/test/controllers/matcher.spec.js
@@ -80,7 +80,7 @@ describe('Order Matcher', function(){
       return order.save()
     })
     .then(function(orders) {
-      return matcher.processOrder(orders[0])
+      return matcher._processOrder(orders[0])
     })
     .then(function(){
       Trade.fetchAll().then(function(trades){
@@ -100,7 +100,7 @@ describe('Order Matcher', function(){
       return order.save()
     })
     .then(function(orders) {
-      return matcher.processOrder(orders[0])
+      return matcher._processOrder(orders[0])
     })
     .then(function(){
       Trade.fetchAll().then(function(trades){


### PR DESCRIPTION
Replaced the builtin node EventEmitter with an async event emitter module:
https://www.npmjs.com/package/async-eventemitter

The order matcher now queues incoming orders to be processed in order. (We might need a way to persist the queue incase of server failure so it can pickup and continue processing on restart)