### PR TITLE
Trade ticker now changes color based on whether the last trade was an up- or down-tick.

### DIFF
--- a/client/app/app.html
+++ b/client/app/app.html
@@ -1,7 +1,7 @@
 <header>
   <nav>
     <a class="home" ui-sref="landing.home">FlyptoX || Currency Exchange</a>
-    <span class="nav-ticker">Last Trade: {{ lastTrade.price }}</span>
+    <span class="nav-ticker" ng-class="tickType">Last Trade: {{ lastTrade.price }}</span>
     <span class="nav-rest">
       <a ui-sref="account" ng-if="auth.isAuth()">Account</a>
       <a ui-sref=".marketview">Market View</a>

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -218,4 +218,14 @@ h2, h3, h4, h5, h6 {
   color: white;
   margin: 0 auto;
   vertical-align: bottom;
+  transition: background-color cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+  -webkit-transition: background-color cubic-bezier(0.250, 0.460, 0.450, 0.940) 0.5s;
+}
+
+.nav-ticker.uptick {
+  background-color: green;
+}
+
+.nav-ticker.downtick {
+  background-color: red;
 }


### PR DESCRIPTION
Couldn't capture a screenshot because it highlights for just about a second. Also, not sure if the color, effects, timing, etc. is final, I doubt it is. But this shows how to do live CSS updates based on events received from socket.io.