### PR TITLE
Account Management page + miscellaneous updates

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -34,8 +34,6 @@ var paths = {
         'client/lib/angular/angular.js',
         'client/lib/angular-ui-router/release/angular-ui-router.js',
         'client/lib/angular-mocks/angular-mocks.js',
-        'client/lib/chartist/dist/chartist.js',
-        'client/lib/angular-chartist.js/dist/angular-chartist.js',
         'client/lib/socket.io-client/socket.io.js'
       ],
 

--- a/client/app/app.html
+++ b/client/app/app.html
@@ -3,7 +3,7 @@
     <a class="home" ui-sref="landing.home">FlyptoX || Currency Exchange</a>
     <span class="nav-ticker" ng-class="tickType">Last Trade: {{ lastTrade.price }}</span>
     <span class="nav-rest">
-      <a ui-sref="account" ng-if="auth.isAuth()">Account</a>
+      <a ui-sref=".account" ng-if="auth.isAuth()">Account</a>
       <a ui-sref=".marketview">Market View</a>
       <a ui-sref=".login" ng-if="!auth.isAuth()">Log In</a>
       <a ng-click="auth.signout()" ng-if="auth.isAuth()">Log Out</a>

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -5,7 +5,6 @@
   // Dependencies for module 'FlyptoX'
   var dependencies = [
     'ui.router',
-    'angular-chartist',
     'FlyptoX.auth',
     'FlyptoX.orderbook',
     'FlyptoX.chart',
@@ -57,37 +56,46 @@
           templateUrl: 'app/components/auth/login.html',
           controller: 'AuthController as auth'
         })
+        .state('landing.account', {
+          url: 'account',
+          templateUrl: 'app/components/account/account.html',
+          controller: 'AccountCtrl as account'
+        });
         // .state('dashboard', {
         //   url: '/dashboard',
         //   templateUrl: 'app/app.html'
         //   // this needs a controller
         //   // but right now its a mishmash
         // })
-        .state('orderbook', {
-          url: '/orderbook',
-          templateUrl: 'app/components/orderbook/orderbook.html',
-          controller: 'OrderbookCtrl as orderbook'
-        })
-        .state('login', {
-          url: '/login',
-          templateUrl: 'app/components/login/login.html',
-          controller: 'AuthController as auth'
-        })
-        .state('signup', {
-          url: '/signup',
-          templateUrl: 'app/components/signup/signup.html',
-          controller: 'AuthController as auth'
-        })
-        .state('chart', {
-          url: '/chart',
-          templateUrl: 'app/components/chart/chart.html',
-          controller: 'chartCtrl'
-        })
-        .state('account', {
-          url: '/account',
-          templateUrl: 'app/components/account/account.html',
-          controller: 'AccountCtrl as account'
-        });
+
+        // (DT) Can probably be deleted
+        //------------------------------------------------------------
+        // .state('orderbook', {
+        //   url: '/orderbook',
+        //   templateUrl: 'app/components/orderbook/orderbook.html',
+        //   controller: 'OrderbookCtrl as orderbook'
+        // })
+        // .state('login', {
+        //   url: '/login',
+        //   templateUrl: 'app/components/login/login.html',
+        //   controller: 'AuthController as auth'
+        // })
+        // .state('signup', {
+        //   url: '/signup',
+        //   templateUrl: 'app/components/signup/signup.html',
+        //   controller: 'AuthController as auth'
+        // })
+        // .state('chart', {
+        //   url: '/chart',
+        //   templateUrl: 'app/components/chart/chart.html',
+        //   controller: 'chartCtrl'
+        // })
+        // .state('account', {
+        //   url: '/account',
+        //   templateUrl: 'app/components/account/account.html',
+        //   controller: 'AccountCtrl as account'
+        // });
+        //-----------------------------------------------------
 
       $httpProvider.interceptors.push('AttachTokens');
       $httpProvider.interceptors.push('authHttpResponseInterceptor');

--- a/client/app/components/account/account.controller.js
+++ b/client/app/components/account/account.controller.js
@@ -3,7 +3,8 @@
 
   app.controller('AccountCtrl', ['$scope', '$http',
     function($scope, $http) {
-      
+      $scope.section = 'history';
+      $scope.filter = 'orders';
 
       $scope.getTrades = function() {
         // Sample of return data

--- a/client/app/components/account/account.html
+++ b/client/app/components/account/account.html
@@ -1,11 +1,52 @@
-<pre ng-init="getTrades()">
+<!-- <pre ng-init="getTrades()">
   {{trades}}
 </pre>
 
 <pre ng-init="getOrders()">
   {{myOrders}}
 </pre>
+ -->
+<!-- Container -->
+<div class="account">
+  <!-- Section Navigation -->
+  <div class="sections">
+    <a ng-click="section='history'">Account History</a>
+    <a ng-click="section='wallets'">Add Account / Wallet</a>
+    <a ng-click="section='settings'">Settings</a>
+    Section: {{section}}
+  </div>
 
+  <!-- Latest (Transactions | Trades | Orders) -->
+  <div class="history" ng-show="section === 'history'">
+    <!-- Filter Buttons -->
+    <div class="filters">
+      <button ng-click="filter='orders'">Orders</button>
+      <button ng-click="filter='trades'">Trades</button>
+      <button ng-click="filter='transactions'">Transactions</button>
+      Filter: {{filter}}
+    </div>
+
+    <!-- Record Listing -->
+    <!-- <table>
+      <tr>
+        <th ng-repeat="column in columns[filter] track by $index">{{column}}</th>
+      </tr>
+      <tr ng-repeat="record in records[filter]">
+        <td ng-repeat="column in columns track by $index">{{record[$index]}}</td>
+      </tr>
+    </table> -->
+  </div>
+
+  <!-- Add Account / Wallet -->
+  <div class="wallets" ng-show="section === 'wallets'">
+    Wallets
+  </div>
+
+  <!-- Settings -->
+  <div class="settings" ng-show="section === 'settings'">
+    Settings
+  </div>
+</div>
 <!-- <div class="orderbook-right-col">
   <div class="execution" data-ng-init="getBook()">
     <h5>Order Entry</h5>

--- a/client/app/components/account/account.scss
+++ b/client/app/components/account/account.scss
@@ -1,0 +1,8 @@
+.sections a {
+  display: block;
+}
+
+div.sections {
+  background-color: green;
+  width: 20%;
+}

--- a/client/app/components/orderbook/orderbook.html
+++ b/client/app/components/orderbook/orderbook.html
@@ -1,8 +1,8 @@
 <div class="ob-wrap">
   <div class="tx" ng-init="getBook()">
-    <div class="offerList" ng-repeat="a in asks">
-      <h7 class="ask"> {{ a[0] }} </h7>
-      <h7 class="ask ask-price"> {{ a[1] }} </h7>
+    <div class="askList" ng-repeat="a in asks">
+      <h7 class="ask"> {{ a[1] }} </h7>
+      <h7 class="ask ask-price"> {{ a[0] }} </h7>
         <svg height="1" width="500">
             <line x1="0" y1="0" x2="300" y2="0"/>
         </svg>
@@ -16,8 +16,8 @@
     </div>
 
     <div class="bidList" ng-repeat="b in bids">
-      <h7 class="bid"> {{ b[0] }} </h7>
-      <h7 class="bid bid-price"> {{ b[1] }} </h7>
+      <h7 class="bid"> {{ b[1] }} </h7>
+      <h7 class="bid bid-price"> {{ b[0] }} </h7>
         <svg height="1" width="500">
             <line x1="0" y1="0" x2="300" y2="0"/>
         </svg>
@@ -29,7 +29,7 @@
   </div>
 
   <div class="orderbook-right-col" ng-if="auth.isAuth()">
-    <div class="execution" >
+    <div class="execution">
       <h5>Order Entry</h5>
       <form class="orderForm" ng-submit="placeOrder()">
 


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/7990780/8940759/94f86346-3539-11e5-9b4b-136b2260ad09.png)

- Account management page layout. Work-in-process for now. Starting with being able to pull and filter various kinds of account history into a table (orders, trades, transactions to start with).
- Remove Chartist.js from dependencies.
- Switch price and size on the orderbook page.
- Fix ui-router to point to state 'account' as a child of state 'landing'.

