### PR TITLE
only send token with /api calls

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -160,11 +160,14 @@
       // then add it to the header so the server can validate the request
       var attach = {
         request: function (object) {
-          var jwt = $window.localStorage.getItem('com.flyptox');
-          if (jwt) {
-            object.headers['x-access-token'] = jwt;
+          //only attach token to api calls to same origin
+          if(object.url.toLowerCase().indexOf('/api/') === 0) {
+            var jwt = $window.localStorage.getItem('com.flyptox');
+            if (jwt) {
+              object.headers['x-access-token'] = jwt;
+            }
+            object.headers['Allow-Control-Allow-Origin'] = '*';
           }
-          object.headers['Allow-Control-Allow-Origin'] = '*';
           return object;
         }
       };

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -162,7 +162,7 @@
         request: function (object) {
           //only attach token to api calls to same origin
           if(object.url.toLowerCase().indexOf('/api/') === 0) {
-            var jwt = $window.localStorage.getItem('com.flyptox');
+            var jwt = $window.sessionStorage.getItem('com.flyptox');
             if (jwt) {
               object.headers['x-access-token'] = jwt;
             }

--- a/client/app/components/auth/auth.controller.js
+++ b/client/app/components/auth/auth.controller.js
@@ -8,7 +8,7 @@
       $scope.signin = function () {
         AuthService.signin($scope.user)
           .then(function (token) {
-            $window.localStorage.setItem('com.flyptox', token);
+            $window.sessionStorage.setItem('com.flyptox', token);
 
             $scope.error = ''; // Clear any previous error messages.
 
@@ -28,7 +28,7 @@
       $scope.signup = function () {
         AuthService.signup($scope.user)
           .then(function (token) {
-            $window.localStorage.setItem('com.flyptox', token);
+            $window.sessionStorage.setItem('com.flyptox', token);
             $scope.error = ''; // Clear any previous error messages.
             //redirect user after successful login
             $state.go('landing.marketview');

--- a/client/app/lib/auth.service.js
+++ b/client/app/lib/auth.service.js
@@ -27,11 +27,11 @@
     };
 
     auth.isAuth = function () {
-      return !!$window.localStorage.getItem('com.flyptox');
+      return !!$window.sessionStorage.getItem('com.flyptox');
     };
 
     auth.signout = function () {
-      $window.localStorage.removeItem('com.flyptox');
+      $window.sessionStorage.removeItem('com.flyptox');
       $state.go('^.home');
     };
 


### PR DESCRIPTION
This ensures that our auth token is only sent with request to /api.
Any $http requests with url starting with http or https could be potentially external api and we wouldn't want them to get our token..

Token will now be stored in sessionStorage instead of localStorage. data stored in sessionStorage will be destroyed when a tab is closed. If a new tab is opened it has it's own sessionStorage so user will require to login again.