### PR TITLE
market order - limit filling order relative to available funds

### DIFF
--- a/server/api/v1.js
+++ b/server/api/v1.js
@@ -248,7 +248,7 @@ body json: none
 query params: none
 */
 router.get("/orders", privateApi, function(req, res){
-  Order.where({status:'open', user_id:req.userId})
+  Order.where({status:'open', user_id:req.userId, type:'limit'})
     .fetchAll({withRelated:['currency_pair']})
     .then(function(orders){
       return orders.map(function(order){
@@ -359,12 +359,12 @@ body json: none
 query params: none
 */
 router.delete("/orders/:id", privateApi, function(req, res){
-  Order.where({user_id:req.userId, id:req.params.id, status:'open'})
+  Order.where({user_id:req.userId, id:req.params.id, status:'open', type:'limit'})
     .fetch({withRelated:'currency_pair'})
     .then(function(order){
       if(order){
         order.set('status', 'done');
-        order.set('done_reason', 'canceled');
+        order.set('done_reason', 'cancelled');
         order.set('done_at', new Date());
         return order.save();
       }

--- a/server/controllers/web-market-streamer.js
+++ b/server/controllers/web-market-streamer.js
@@ -3,6 +3,7 @@ var socketio = require('socket.io');
 var io;
 
 appEvents.on('order:new', function(order) {
+  if(order.type !== 'limit') return;
   console.log('New order created server-side! Notifying clients...');
   io.emit('order:new', order);
 });

--- a/server/test/controllers/matcher.spec.js
+++ b/server/test/controllers/matcher.spec.js
@@ -10,29 +10,21 @@ var Order = bookshelf.model('Order');
 var Trade = bookshelf.model('Trade');
 var Promise = require('bluebird');
 
-function clearTradesAndOrders(done){
+function clearTables(done){
   bookshelf.knex('transactions').del()
   .then(function(){
-    return bookshelf.knex('trades').del()
+      return bookshelf.knex('trades').del();
   })
   .then(function(){
       return bookshelf.knex('orders').del();
   })
-  .finally(function(){
-    //bookshelf.knex.destroy();
-    done();
-  });
-}
-
-function clearUsers(done){
-  bookshelf.knex('accounts').del()
+  .then(function(){
+    return bookshelf.knex('accounts').del();
+  })
   .then(function(){
     return bookshelf.knex('users').del()
   })
-  .finally(function(){
-    //bookshelf.knex.destroy();
-    done();
-  });
+  .finally(done);
 }
 
 
@@ -50,15 +42,11 @@ function makeOrder(user_id, side, price, size) {
 
 describe('Order Matcher', function(){
 
-  beforeEach(clearTradesAndOrders);
-  afterEach(clearTradesAndOrders);
-
   var alice_id, bob_id;
 
-  before(clearTradesAndOrders);
-  before(clearUsers);
+  beforeEach(clearTables);
 
-  before(function(done){
+  beforeEach(function(done){
     users.signup("alice", "alice")
     .then(function(user){
       alice_id = user.id;
@@ -66,7 +54,7 @@ describe('Order Matcher', function(){
     .finally(done);
   });
 
-  before(function(done){
+  beforeEach(function(done){
     users.signup("bob", "bob")
     .then(function(user){
       bob_id = user.id;
@@ -74,8 +62,8 @@ describe('Order Matcher', function(){
     .finally(done);
   });
 
-  after(clearUsers);
-
+  after(clearTables);
+  
   it('shoud create one trade from two exact matching orders', function(done){
     Promise.map([
       Order.forge(makeOrder(alice_id, 'buy', 200, 1)),


### PR DESCRIPTION
a market order will only be filled up to maximum possible given a user's available funds
a market order will not execute if available balance equals zero

In the mean time I tested it. looks to be working.. try it out.. see if you can break it or find a problem with the code let me know.

streamer will not send new:order messages for market orders.

~~UI needs be updated not to add market orders to list of open orders~~ 

`/api/v1/orders` now only returns limit orders (it doesn't make sense to show market orders in the open orders list)

only limit orders can be cancelled, market orders will automatically complete once either the market is exhausted or the user's balance drops to zero
