### PR TITLE
BTC formatting, 'equaltick' effect on the ticker, wallet balances on the accounts page.

### DIFF
--- a/client/app/app.js
+++ b/client/app/app.js
@@ -109,31 +109,24 @@
 
   //---------------------------------------------------------
   // controller for our root level page
-  app.controller('LandingController', ['$scope', '$state', '$http', '$timeout', 'AuthService',
-    function($scope, $state, $http, $timeout, AuthService){
+  app.controller('LandingController', ['$scope', '$state', '$http',
+                                       '$timeout', 'AuthService', 'APIService',
+    function($scope, $state, $http, $timeout, AuthService, APIService){
       $scope.auth = AuthService;
 
-      $http({
-        method: 'GET',
-        url: '/api/v1/products/1/ticker'
-      })
-      .success(function(data, status, headers, config, statusText) {
-        // data = {
-        //   "id": trade-id,
-        //   "price": "301.00",
-        //   "size": "1.50000000",
-        //   "time": "2015-05-05T23:17:30.310036Z"
-        // }
+      APIService.get('products/1/ticker', function(data) {
         $scope.lastTrade = data;
-      })
-      .error(function(data, status, headers, config, statusText) {
-
       });
 
       socket.on('trade', function(tradeData) {
         // Sets the tickType so that the ng-class directive gets activated
-        // TODO: What should happen when the previous trade price is the same as the most recent trade price?
-        $scope.tickType = tradeData.price > $scope.lastTrade.price ? 'uptick' : 'downtick';
+        if (tradeData.price > $scope.lastTrade.price) {
+          $scope.tickType = 'uptick';
+        } else if (tradeData.price < $scope.lastTrade.price) {
+          $scope.tickType = 'downtick';
+        } else {
+          $scope.tickType = 'equaltick';
+        }
 
         $timeout(function() {
            // Clear the tickType class to reverse the transition

--- a/client/app/app.scss
+++ b/client/app/app.scss
@@ -241,6 +241,11 @@ h2, h3, h4, h5, h6 {
 .nav-ticker.downtick {
   background-color: red;
 }
+
+.nav-ticker.equaltick {
+  background-color: #423B67;
+}
+
 .section {
   background-color: #FFF;
   width: 100%;

--- a/client/app/components/account/account.controller.js
+++ b/client/app/components/account/account.controller.js
@@ -11,7 +11,7 @@
         'transactions': ['credit', 'debit', 'type']
       };
       $scope.records = {};
-
+      $scope.balances = {};
 
       $scope.getTrades = function() {
         // [
@@ -53,7 +53,7 @@
         });
       };
 
-      $scope.getTransactions = function() {
+      $scope.getTransactions = function(currency_id) {
         // [
         //  {
         //   id: account.id,
@@ -74,11 +74,26 @@
           //   //transfer_id: transaction.get('transfer_id'),
           //  }
           // ]
-          APIService.get('accounts/' + accounts[0].id + '/ledger', function(data) {
+          APIService.get('accounts/' + accounts[currency_id].id + '/ledger', function(data) {
             $scope.records['transactions'] = data;
           });
         });
       };
+
+      // Initialize account balances
+      (function(){
+        APIService.get('accounts', function(accounts) {
+          APIService.get('accounts/' + accounts[0].id, function(data) {
+            $scope.balances['usd'] = data.balance;
+            $scope.balances['usd-available'] = data.available;
+          });
+
+          APIService.get('accounts/' + accounts[1].id, function(data) {
+            $scope.balances['btc'] = data.balance;
+            $scope.balances['btc-available'] = data.available;
+          });
+        });
+      })();
 
     }]); // app.controller
 })(); // anonymous function

--- a/client/app/components/account/account.html
+++ b/client/app/components/account/account.html
@@ -5,7 +5,7 @@
 </pre>
 
 <!-- Container -->
-<div class="account" ng-init="getTransactions()">
+<div class="account" ng-init="getTransactions(0)">
   <!-- Section Navigation -->
   <div class="sections">
     <a ng-click="section='history'">Account History</a>
@@ -15,6 +15,7 @@
 
   <!-- Latest (Transactions | Trades | Orders) -->
   <div class=" history" ng-show="section === 'history'">
+    <h1>Last 20 {{filter}}</h1>
     <!-- Filter Buttons -->
     <div class="filters">
       <button ng-click="filter='orders'">Orders</button>
@@ -27,7 +28,7 @@
       <tr class="headings">
         <th ng-repeat="column in columns[filter]">{{column}}</th>
       </tr>
-      <tr class="record" ng-repeat="record in records[filter]">
+      <tr class="record" ng-repeat="record in records[filter] | limitTo: 20">
         <td ng-repeat="column in columns[filter]">{{record[column]}}</td>
       </tr>
     </table>
@@ -35,11 +36,65 @@
 
   <!-- Add Account / Wallet -->
   <div class="wallets" ng-show="section === 'wallets'">
-    Wallets
+    <h1>Wallet Balances</h1>
+    <table>
+      <tr class="headings">
+        <th>Currency</th>
+        <th>Total Balance</th>
+        <th>Available Balance</th>
+      </tr>
+      <tr class="record">
+        <td>USD</td>
+        <td>{{balances['usd'] | currency}}</td>
+        <td>{{balances['usd-available'] | currency}}</td>
+      </tr>
+      <tr class="record">
+        <td>BTC</td>
+        <td>{{balances['btc']}}</td>
+        <td>{{balances['btc-available']}}</td>
+      </tr>
+    </table>
   </div>
 
   <!-- Settings -->
   <div class="settings" ng-show="section === 'settings'">
-    Settings
+    <form class="settingsForm">
+
+        <div class="execDetails">
+          <label>Currency</label>
+          <select ng-model="orderData.currency_pair_id"
+                  ng-options="pair.value as pair.label for pair in pairs"
+                  required>
+          </select>
+        </div>
+
+        <div class="execDetails">
+          <label>Type</label>
+          <select ng-model="orderData.type"
+                  ng-options="type for type in types"
+                  required>
+          </select>
+        </div>
+
+        <div class="execDetails" ng-if="orderData.type !== 'market'">
+          <label>Price</label>
+          <input ng-model="orderData.price" type="number" step="any" required>
+        </div>
+
+        <div class="execDetails">
+          <label>Side</label>
+          <select ng-model="orderData.side"
+                  ng-options="side for side in sides" required>
+          </select>
+        </div>
+
+        <div class="execDetails">
+          <label>Size</label>
+          <input ng-model="orderData.size" type="number" step="any" required>
+        </div>
+
+        <button type="submit">Submit<button>
+
+      </form>
   </div>
 </div>

--- a/client/app/components/account/account.scss
+++ b/client/app/components/account/account.scss
@@ -23,7 +23,7 @@ div.sections {
   margin-top: 50%;
 }
 
-div.history {
+div.history, div.wallets {
   width: 80%;
   display: inline-block;
   float: right;
@@ -73,11 +73,11 @@ div.filters {
   }
 }
 
-.history table {
+.history table, .wallets table {
   margin: 1% auto 0 auto;
 }
 
-.history td {
+.history td, .wallets td {
   width: 10%;
   text-align: center;
   padding-top: 5px;

--- a/client/app/components/orderbook/orderbook.controller.js
+++ b/client/app/components/orderbook/orderbook.controller.js
@@ -90,8 +90,7 @@
         $scope.getBook();
       });
 
-      socket.on('trade', function(order) {
-        console.log('Trade occurred!');
+      socket.on('trade', function(trade) {
         $scope.getBook();
         $scope.getOrders();
       });

--- a/client/app/components/orderbook/orderbook.html
+++ b/client/app/components/orderbook/orderbook.html
@@ -38,7 +38,7 @@
     <div class="balances execution">
       <h5>Wallet Balances</h5>
       <div class="usd-balance">USD Balance: {{balances['usd'] | currency}} / Avail: {{balances['usd-available'] | currency}}</div>
-      <div class="btc-balance">BTC Balance: {{balances['btc'] | currency}} / Avail: {{balances['btc-available'] | currency}}</div>
+      <div class="btc-balance">BTC Balance: {{balances['btc']}} / Avail: {{balances['btc-available']}}</div>
     </div>
 
     <div class="execution" ng-init="getBalance()">


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/7990780/9001185/0a76a95e-3722-11e5-8fd7-a74c7454ae14.png)

- Add a neutral colored effect on the trade ticker in the case when the current trade executes at the same price as the previous price, a.k.a. an "equal-tick" (yes, I made that up).

- Remove currency formatting from the BTC figures on the orderbook page.