### PR TITLE
Auto height for inline divs on account page

### DIFF
--- a/client/app/components/account/account.scss
+++ b/client/app/components/account/account.scss
@@ -77,7 +77,8 @@ div.filters {
 }
 
 .history table, .wallets table {
-  margin: 1% auto 0 auto;
+  margin: 2% auto 1% auto;
+  width: 80%;
 }
 
 .history td, .wallets td {

--- a/client/app/components/account/account.scss
+++ b/client/app/components/account/account.scss
@@ -1,13 +1,18 @@
 .account {
   height: 100%;
+  display: table;
+}
+
+.account > div {
+  float: none;
+  display: table-cell;
+  vertical-align: top;
 }
 
 div.sections {
   width: 20%;
   max-width: 20%;
   min-width: 180px;
-  display: inline-block;
-  vertical-align: top;
   background: rgb(49,52,66);
 }
 
@@ -25,8 +30,6 @@ div.sections {
 
 div.history, div.wallets {
   width: 80%;
-  display: inline-block;
-  float: right;
   padding: 9px 0px;
   height: 100%;
   background: rgb(230,230,230);
@@ -81,8 +84,10 @@ div.filters {
   width: 10%;
   text-align: center;
   padding-top: 5px;
+  height: 25px;
 }
 
 .headings {
   font-weight: bold;
+  height: 25px;
 }


### PR DESCRIPTION
The two inline divs previously would separate into two rows when the window was too small. I've changed the display from inline-block to table-cell and tweaked the CSS slightly for spacing.

<img width="1098" alt="screen shot 2015-07-31 at 13 03 50" src="https://cloud.githubusercontent.com/assets/6635402/9012660/ab9a1bce-3784-11e5-874c-8ed45e36431f.png">
